### PR TITLE
Use the .env.local configuration if the file exists

### DIFF
--- a/src/Utility/Configuration.php
+++ b/src/Utility/Configuration.php
@@ -48,7 +48,7 @@ class Configuration
         return new Configuration($values);
     }
 
-    public static function fromLocal()
+    public static function fromLocal(): Configuration
     {
         if (file_exists(getcwd() . '/.env.local')) {
             $path = getcwd() . '/.env.local';

--- a/src/Utility/Configuration.php
+++ b/src/Utility/Configuration.php
@@ -37,8 +37,12 @@ class Configuration
     {
         $values = [];
 
-        // check if we have a .env file
+        // check if we have a .env.local or .env file
         $envPath = Deployer\get('deploy_path') . '/shared/.env';
+        if (Deployer\test("[ -f $envPath.local ]")) {
+            $envPath .= '.local';
+        }
+
         if (Deployer\test("[ -f $envPath ]")) {
             $values = (new Dotenv())->parse(
                 Deployer\run("cat $envPath")


### PR DESCRIPTION
We use the .env.local file in the shared folder to set the database credentials since we don't commit database credentials to the git repo. I have provided a check that uses the .env.local file if it exists.