### PR TITLE
Use shared directory path as base directory to copy the shared files/directories into

### DIFF
--- a/recipe/files.php
+++ b/recipe/files.php
@@ -15,7 +15,7 @@ task(
             $path = '{{deploy_path}}/shared/' . $directory;
 
             if (test(sprintf('[ -d %1$s ]', $path))) {
-                download($path, './');
+                download($path, $directory . '/../');
             }
         }
     }


### PR DESCRIPTION
The download command was copying the shared files and directory to the root of the project instead of using the shared directory's path.
This PR changes the destination of the files to the parent directory of the original shared directory so that it copies the files to the expected path.