### PR TITLE
Do it before the symlink is created, otherwise there will be a brief …

### DIFF
--- a/recipe/assets.php
+++ b/recipe/assets.php
@@ -11,4 +11,4 @@ task(
 );
 
 // add it to the flow
-after('deploy:symlink', 'sumo:assets:install');
+before('deploy:symlink', 'sumo:assets:install');


### PR DESCRIPTION
…moment when the assets are not available