### PR TITLE
Added command to create SSL certificate on staging

### DIFF
--- a/recipe/ssl.php
+++ b/recipe/ssl.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Deployer;
+
+desc('Create the SSL certificate for the staging url');
+task(
+    'sumo:ssl:create',
+    function () {
+        $command = sprintf(
+            'create_ssl %1$s.%2$s.%3$s',
+            get('project'),
+            get('client'),
+            'php' . str_replace('.', '', get('php_version'))
+        );
+
+        writeln(
+            run($command)
+        );
+    }
+)->select('stage=staging');

--- a/sumo.php
+++ b/sumo.php
@@ -11,3 +11,4 @@ require_once 'recipe/redirect.php';
 require_once 'recipe/symlink.php';
 require_once 'recipe/opcache.php';
 require_once 'recipe/project.php';
+require_once 'recipe/ssl.php';


### PR DESCRIPTION
In the past we used caddy on the staging server to create certificates manually.
Certificate were generated if needed, but we ran into rate limits.

So from now on we will create/request the certificates ourself, by running:
`sumo:ssl:create`

See: https://app.activecollab.com/108877/projects/45/tasks/140096