### PR TITLE
Fix deploy notification

### DIFF
--- a/recipe/notifications.php
+++ b/recipe/notifications.php
@@ -15,7 +15,7 @@ task(
             ->jsonBody(
                 [
                     'local_username' => getenv('USER'),
-                    'stage' => get('stage'),
+                    'stage' => get('labels')['stage'] ?? null,
                     'repo' => get('repository'),
                     'revision' => $gitUtility->getCurrentHash(),
                 ]


### PR DESCRIPTION
Since deployer 7, the stage name is set bij labels.