### PR TITLE
Better indicate failure to reset opcache

### DIFF
--- a/recipe/opcache.php
+++ b/recipe/opcache.php
@@ -15,7 +15,7 @@ task('sumo:opcache:reset-file', function () {
     );
 
     $response = Httpie::get(get('production_url') . '/' . $opcacheResetScript)->send();
-    if ($response === false) {
+    if ($response !== '') {
         writeln('<comment>Could not perform an opcache reset via file.</comment>');
     }
 


### PR DESCRIPTION
Opcache reset response should be empty, for example 'File not found' is a response that indicates a failure.