### PR TITLE
Consistent naming of the opcache reset file

### DIFF
--- a/recipe/opcache.php
+++ b/recipe/opcache.php
@@ -6,7 +6,7 @@ use Deployer\Utility\Httpie;
 
 desc('Reset the opcache using a file strategy');
 task('sumo:opcache:reset-file', function () {
-    $opcacheResetScript = 'php-opcache_reset.php';
+    $opcacheResetScript = 'php-opcache-reset.php';
     $scriptPath = '{{ document_root }}/' . $opcacheResetScript;
 
     run(


### PR DESCRIPTION
Rename to the same name as the old capistrano one, matching the name in the .htaccess file of forkcms.