### PR TITLE
Remove assets after upload

### DIFF
--- a/recipe/assets.php
+++ b/recipe/assets.php
@@ -79,6 +79,15 @@ task(
     }
 );
 
+desc('Remove built assets for local development');
+task(
+    'sumo:assets:remove',
+    function () {
+        runLocally('rm -rf public/assets');
+    }
+);
+
 // Specify order during deploy
 after('deploy:update_code', 'sumo:assets:build');
 after('sumo:assets:build', 'sumo:assets:upload');
+after('sumo:assets:upload', 'sumo:assets:remove');


### PR DESCRIPTION
On deploy we run `symfony console asset-map:compile`. Which compiles the assets in public/assets. For local development you don't want this folder because non of your changes in js/css will be working. So after uploading the assets, remove the compiles assets again.